### PR TITLE
Add functionality to set the Account Type

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -27,6 +27,7 @@ class Gateway extends AbstractGateway
             'username'      => '',
             'password'      => '',
             'applyThreeDSecure' => false,
+            'accountType'   => 'ECOM',
         );
     }
 
@@ -96,6 +97,23 @@ class Gateway extends AbstractGateway
     public function setApplyThreeDSecure($value)
     {
         return $this->setParameter('applyThreeDSecure', $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountType()
+    {
+        return $this->getParameter('accountType');
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function setAccountType($value)
+    {
+        return $this->setParameter('accountType', $value);
     }
 
 

--- a/src/Message/AbstractPurchaseRequest.php
+++ b/src/Message/AbstractPurchaseRequest.php
@@ -93,7 +93,7 @@ abstract class AbstractPurchaseRequest extends AbstractRequest
 
         /** @var SimpleXmlElement $operation */
         $operation = $request->operation;
-        $operation->addChild('accounttypedescription', 'ECOM');
+        $operation->addChild('accounttypedescription', $this->getAccountType());
         $operation->addChild('authmethod', 'FINAL');
 
         $billing = $request->addChild('billing');

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -89,6 +89,23 @@ abstract class AbstractRequest extends BaseAbstractRequest
     }
 
     /**
+     * @return string
+     */
+    public function getAccountType()
+    {
+        return $this->getParameter('accountType');
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function setAccountType($value)
+    {
+        return $this->setParameter('accountType', $value);
+    }
+
+    /**
      * @return SimpleXMLElement
      */
     public function getBaseData()

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -32,6 +32,7 @@ class GatewayTest extends GatewayTestCase
         $this->gateway->setSiteReference('dummy_site_reference');
         $this->gateway->setUsername('username@dummy.local');
         $this->gateway->setPassword('pass123');
+        $this->gateway->setAccountType('ECOM');
 
         $this->options = array(
             'amount'        => '0.98',
@@ -46,6 +47,7 @@ class GatewayTest extends GatewayTestCase
         $this->assertSame('dummy_site_reference', $this->gateway->getSiteReference());
         $this->assertSame('username@dummy.local', $this->gateway->getUsername());
         $this->assertSame('pass123', $this->gateway->getPassword());
+        $this->assertSame('ECOM', $this->gateway->getAccountType());
     }
 
     public function testPurchaseSuccess()

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -19,6 +19,7 @@ abstract class AbstractRequestTest extends TestCase
             'username'      => 'test-username',
             'password'      => 'test-password',
             'transactionId' => 'test-1234',
+            'accountType'   => 'ECOM',
         );
     }
 
@@ -30,5 +31,6 @@ abstract class AbstractRequestTest extends TestCase
         $this->assertSame('test-site-reference', (string)$data->request->operation->sitereference);
         $this->assertSame('test-1234', (string)$data->request->merchant->orderreference);
         $this->assertSame('test-password', $this->request->getPassword());
+        $this->assertSame('ECOM', $this->request->getAccountType());
     }
 }


### PR DESCRIPTION
This pull requests allows the Account Type to be set. By default the type is set to `ECOM` but this now allows other types (eg: `MOTO`) to be used.
